### PR TITLE
Export TraceT data constructor

### DIFF
--- a/src/Control/Monad/Trace.hs
+++ b/src/Control/Monad/Trace.hs
@@ -9,7 +9,7 @@
 module Control.Monad.Trace (
   -- * Tracers
   Tracer, newTracer,
-  runTraceT, runTraceT', TraceT,
+  runTraceT, runTraceT', TraceT(..),
 
   -- * Collected data
   -- | Tracers currently expose two pieces of data: completed spans and pending span count. Note


### PR DESCRIPTION
First of all, I'd like to thank you for your great work on this library!

This PR exports the` TraceT` data constructor, thus allowing for more instances for `TraceT` to be defined.

The project I'm working on unfortunately doesn't  work well with `UnliftIO`, so I have to define instances for `MonadBaseControl IO`.